### PR TITLE
Migrate GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,18 +15,23 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
     - cron: '42 5 * * 3'
-
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-codeql-python/.github/workflows/workflow.yml@ca5a2fbce666756cb15aca6e3a33852588728909  # v1.0.0
     permissions:
-      # required for all workflows
       security-events: write
-      # required to fetch internal or private CodeQL packs
       packages: read
-      # only required for workflows in private repositories
       actions: read
       contents: read
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-codeql-analysis.yml@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 permissions:
-  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
-  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  contents: read
 jobs:
   call-workflow:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-deploy.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-deploy/.github/workflows/workflow.yml@eab497a87ebe0cc07a02f723660b750be925f4aa  # v1.0.0
     secrets:
       pypi_password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -2,9 +2,15 @@ on:
   push:
     branches:
       - main
+# For OIDC token exchange with Qlty:
+# - Configuring OpenID Connect in cloud providers - GitHub Docs
+#   https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings
+permissions:
+  contents: read
+  id-token: write
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-qlty/.github/workflows/workflow.yml@732676e4d8cea832b97f2f66ee73fd65fa837e7d  # v1.0.0
     permissions:
       contents: read
       id-token: write
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-qlty.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,12 @@ on:
     branches:
       - main
 permissions:
-  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
-  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  contents: read
 jobs:
   call-workflow-test:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-test.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-test/.github/workflows/workflow.yml@3deca6708b4c2b623c7eac175a63973c05c64e3b  # v1.0.0
     with:
       support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
       is-supporting-python-3-7-in-linux: true
   call-workflow-lint:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-lint.yml@main
-    with:
-      enable-xenon: false
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-lint/.github/workflows/workflow.yml@0966c64de69c044585bbdca96980a8393c761829  # v1.0.0


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to use new, version-pinned reusable workflows from external repositories, instead of referencing the old monolithic workflow files. Additionally, it improves permissions settings for better security and clarity, and adds comments to guide future maintenance.

Workflow migration and improvements:

* Migrated the `test.yml`, `lint.yml`, `deploy.yml`, and `qlty.yml` workflows to use new, versioned reusable workflows from the `reusable-workflow-invoke-lint-*` repositories, ensuring more maintainable and stable CI/CD processes. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-R18) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-R9) [[3]](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbR5-L10)
* Updated the `codeql.yml` workflow to use the new `reusable-workflow-codeql-python` workflow, and clarified branch filters and permissions. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R18-L23) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L32-R37)

Permissions and documentation enhancements:

* Cleaned up permissions in all workflow files for clarity and least privilege, and added documentation comments, especially to clarify OIDC token usage in `qlty.yml`. [[1]](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbR5-L10) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-R18) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-R9)

These changes modernize the CI/CD setup, improve security, and make workflows easier to update and maintain.