### PR TITLE
Organize dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,51 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
-    "bandit",
-    "build",
     "bump-my-version",
-    "cohesion",
-    # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-    # so we should avoid 3.5.3 or lower.
-    # - Command: "pipenv install --skip-lock" fails 
-    #   since it tries to parse legacy package metadata and raise InstallError
-    #   · Issue #5595 · pypa/pipenv
-    #   https://github.com/pypa/pipenv/issues/5595
-    "coverage>=3.5.4",
-    # The dlint less than 0.14.0 limits max version of flake8.
-    # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-    #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-    "dlint>=0.14.0",
-    # We exclude docformatter versions before 1.7.8 because they depend on untokenize==0.1.1,
-    # whose setup.py uses ast.Constant.s that was removed in Python 3.14.
-    # docformatter 1.7.8 and later require Python 3.10 or later instead of untokenize.
-    # And, we specify as follows if the latest supported Python version is less than 3.11,
-    # so that docformatter can read the settings in pyproject.toml:
-    "docformatter[tomli]>=1.7.8; python_version < '3.11' and python_version >= '3.10'",
-    "docformatter>=1.7.8; python_version >= '3.11'",
-    "dodgy",
-    # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-    # We should avoid the versions that is not compatible with the hacking,
-    # considering the speed of dependency calculation process
-    "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-    # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-    # - Using Black with other tools - Black 25.1.0 documentation
-    #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-    "flake8-bugbear",
-    # To use pyproject.toml for Flake8 configuration
-    "Flake8-pyproject",
-    # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-    # When unpin hacking, it has possibility to install too legacy version of hacking.
-    "hacking>=5.0.0; python_version >= '3.8'",
-    "invokelint>=0.8.1",
-    "mypy",
-    "pylint",
-    "pytest",
+    "invokelint[basic]>=0.19.0",
     "pytest-resource-path",
     "pyvelocity; python_version >= '3.9'",
-    "ruff",
-    "semgrep; python_version>='3.9' or platform_system=='Linux'",
-    "types-invoke",
 ]
 
 [project]


### PR DESCRIPTION
This pull request updates the development dependencies in the `pyproject.toml` file, significantly simplifying and reducing the list of packages required for development. Most linting, formatting, and static analysis tools have been removed or replaced, likely to streamline the development environment or in preparation for a new workflow.

Dependency management updates:

* Removed a large number of development dependencies, including `bandit`, `build`, `cohesion`, `coverage`, `dlint`, `docformatter`, `dodgy`, `flake8`, `flake8-bugbear`, `Flake8-pyproject`, `hacking`, `mypy`, `pylint`, `pytest`, `ruff`, `semgrep`, and `types-invoke`, as well as many related version constraints and comments.
* Updated the `invokelint` dependency to use the `[basic]` extra and increased the minimum version to `0.19.0`.
* Retained only a minimal set of development dependencies: `bump-my-version`, `invokelint[basic]>=0.19.0`, `pytest-resource-path`, and `pyvelocity` (for Python >= 3.9).